### PR TITLE
Add global variable to pass an index of all posts to the singlePost function

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,10 @@ function gulpFlatBlog(templates) {
       path: 'index.html'
     });
     for (i in posts) {
-      pageIndex.push(posts[i]);
+      if (pageIndex.includes(posts[i])) {
+      } else {
+          pageIndex.push(posts[i]);
+      }
     }
     file.contents = new Buffer(templates.index({
       posts: posts

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ var File = require('vinyl');
 var path = require('path');
 var hljs = require('highlight.js');
 
+var pageIndex = [];
+
 var markdownit = require('markdown-it')({
   highlight: function(str, lang) {
     if (lang && hljs.getLanguage(lang)) {
@@ -53,7 +55,7 @@ function gulpFlatBlog(templates) {
         post.slug = file.relative.substring(0, file.relative.lastIndexOf('.'));
       }
 
-      file.contents = new Buffer(templates.single(post));
+      file.contents = new Buffer(templates.single({post: post, index: pageIndex}));
       file.path = path.join(file.base, post.slug + '.html');
 
       post.createdAt = file.stat.birthtime;
@@ -73,6 +75,9 @@ function gulpFlatBlog(templates) {
     var file = new File({
       path: 'index.html'
     });
+    for (i in posts) {
+      pageIndex.push(posts[i]);
+    }
     file.contents = new Buffer(templates.index({
       posts: posts
     }));

--- a/test/single.hbs
+++ b/test/single.hbs
@@ -1,3 +1,8 @@
+{{#index}}
+  <a href="/blog/{{slug}}.html">{{title}}</a>
+{{/index}}
+
+{{#post}}
 <article>
   <header>
     <h1>{{title}}</h1>
@@ -6,3 +11,4 @@
     {{{body}}}
   </section>
 </article>
+{{/post}}


### PR DESCRIPTION
Add a `for` loop to `allPosts()` to push an index of posts to a global array, and change `singlePost()`'s `buffer` to pass the `index` variable as well as the original `post` as an object to display a list of all posts from the `single.hbs` template